### PR TITLE
what if bridge was a singleton?

### DIFF
--- a/src/library/client.ts
+++ b/src/library/client.ts
@@ -21,6 +21,8 @@ export class BridgeClient {
 	private internalPlaylists: Playlist[]
 	private currentPlaylist: number
 	private eventsource: BridgeEventSource
+	static instance: any
+	static verbosity: 0 | 1 | 2 | 3 = 0
 
 	constructor() {
 		this.orchestration = ""
@@ -29,10 +31,19 @@ export class BridgeClient {
 		this.CreateOrchestration()
 		this.internalPlaylists = []
 		this.currentPlaylist = 0
+
+		if (!BridgeClient.instance) {
+			BridgeClient.instance = this
+		} else {
+			return BridgeClient.instance
+		}
 	}
 
-	static async init() {
-		new BridgeClient()
+	static getInstance() {
+		if (!BridgeClient.instance) {
+			BridgeClient.instance = new BridgeClient()
+		}
+		return BridgeClient.instance
 	}
 
 	/**
@@ -194,5 +205,13 @@ export class BridgeClient {
 
 	public addEventListener(event: BridgeEvent, MessageHandler: any) {
 		this.eventsource.AddMessageHandler({ event: event, MessageHandler: MessageHandler })
+	}
+
+	public getVerbosity() {
+		return BridgeClient.verbosity
+	}
+
+	public setVerbosity(verbosity: 0 | 1 | 2 | 3) {
+		BridgeClient.verbosity = verbosity
 	}
 }

--- a/src/library/components/endpoints.ts
+++ b/src/library/components/endpoints.ts
@@ -1,3 +1,5 @@
+import { Bridge } from ".."
+
 export type BridgeEndpointType =
 	| "instance_studio_playlist"
 	| "bridge_version"
@@ -64,10 +66,16 @@ export async function sendMessage({ endpoint, requestBody, baseURL, errorMessage
 
 	try {
 		let data = await response.json()
+		if (Bridge.getVerbosity() == 0) {
+			console.log(data)
+		} else if (Bridge.getVerbosity() == 1) {
+			console.log(data.status)
+		}
+
 		return data
 	} catch (error) {
 		// if we have a custom error message, return that, otherwise return the full error
-		if (errorMessage !== undefined) {
+		if (errorMessage !== undefined || Bridge.getVerbosity() == 0) {
 			throw new Error(errorMessage)
 		} else {
 			console.error(error)

--- a/src/library/index.ts
+++ b/src/library/index.ts
@@ -1,3 +1,5 @@
-export * from "./client"
+import { BridgeClient } from "./client"
+export const Bridge = BridgeClient.getInstance()
+// export other helper functions and types
 export * from "./playlists/playlist"
 export * from "./playlists/playlistItems"

--- a/src/react-app/App.tsx
+++ b/src/react-app/App.tsx
@@ -1,7 +1,7 @@
-import { BridgeClient } from "../library/client"
+import { Bridge } from "../library/index"
 import { QuiltPlaylistItem, RGBDPlaylistItem } from "../library/playlists/playlistItems"
 
-const Bridge = new BridgeClient()
+Bridge.setVerbosity(0)
 
 const hologram = QuiltPlaylistItem({
 	URI: "https://s3.amazonaws.com/lkg-blocks/u/9aa4b54a7346471d/steampunk_qs8x13.jpg",


### PR DESCRIPTION
This PR gives us an idea of what it'd look like to make the Bridge object a singleton. 

This means only one bridge client would exist. 

It'd allow us to share/use the bridgeclient elsewhere in the codebase as well. 

An example here I used is a get/setter for error verbosity, which allows us (and our end users) to control how the rest of the codebase logs errors. 