### PR TITLE
add current commit hash to app page

### DIFF
--- a/src/react-app/App.tsx
+++ b/src/react-app/App.tsx
@@ -32,6 +32,9 @@ const rgbd = new RGBDHologram({
 })
 
 function App() {
+	// link setup for hash commit link
+	const githubRepo = "https://github.com/Looking-Glass/Bridge.js"
+	const commitUrl = `${githubRepo}/commit/${__COMMIT_HASH__}`
 	// State for managing connection status
 	const [connected, setConnected] = useState(false)
 	const [connectionStatus, setConnectionStatus] = useState<string>(
@@ -119,6 +122,19 @@ function App() {
 	return (
 		<>
 			<h1>Looking Glass Bridge API Library</h1>
+			<h2>
+				bridge.js is open source on{" "}
+				<a href={githubRepo} target="_blank" rel="noopener noreferrer">
+					Github
+				</a>
+				! 🥳
+			</h2>
+			<p>
+				Current Commit Hash:
+				<a href={commitUrl} target="_blank" rel="noopener noreferrer">
+					{__COMMIT_HASH__}
+				</a>
+			</p>
 			<h2>Status: {`${connectionStatus}`}</h2>
 			<h2>Displays: {`${displays}`}</h2>
 

--- a/src/react-app/index.d.ts
+++ b/src/react-app/index.d.ts
@@ -1,0 +1,1 @@
+declare var __COMMIT_HASH__: string

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -47,6 +47,9 @@ export default defineConfig(({ mode }) => {
 			},
 		}
 	} else if (mode === "react") {
+		// get the current git commit so we can view/link to the source code
+		const commitHash = require("child_process").execSync("git rev-parse --short HEAD").toString()
+		console.log("commit hash:", commitHash)
 		return {
 			build: {
 				outDir: "app",
@@ -56,6 +59,9 @@ export default defineConfig(({ mode }) => {
 				alias: {
 					"@library": path.resolve(__dirname, "./src/library"),
 				},
+			},
+			define: {
+				__COMMIT_HASH__: JSON.stringify(commitHash),
 			},
 			rollupOptions: {
 				external: [],


### PR DESCRIPTION
This PR adds a link to the current commit hash to the preview page. Fixes BLK-571