### PR TITLE
Add TypeScript definitions to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
 	"module": "./dist/looking-glass-bridge.mjs",
 	"exports": {
 		".": {
+			"types": "./dist/index.d.ts",
 			"import": "./dist/looking-glass-bridge.js",
 			"require": "./dist/looking-glass-bridge.mjs"
 		}


### PR DESCRIPTION
This adds the TypeScript types to the package.json allowing discovery from LSPs and improving the DX